### PR TITLE
Select new and modified addon compared to a git branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pip install --user manifestoo
 Manifestoo is a command line tool that provides the following features:
 
 * listing addons,
-* listing modified addons on a feature branch,
+* listing modified or new addons on a feature branch,
 * listing direct and transitive dependencies of selected addons,
 * listing direct and transitive co-dependencies of selected addons,
 * listing core Odoo CE and EE addons,
@@ -74,6 +74,11 @@ It is possible to select modified addons compared to a target branch `target`.
 $ manifestoo --addons-path /tmp/myaddons --select-git-modified target list
 a
 b
+c
+```
+To instead get only newly added addons, use (shortcut `-n`):
+```console
+$ manifestoo --addons-path /tmp/myaddons --select-git-new target list
 c
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ pip install --user manifestoo
 Manifestoo is a command line tool that provides the following features:
 
 * listing addons,
+* listing modified addons on a feature branch,
 * listing direct and transitive dependencies of selected addons,
 * listing direct and transitive co-dependencies of selected addons,
 * listing core Odoo CE and EE addons,
@@ -65,6 +66,15 @@ mkdir -p /tmp/myaddons/{a,b,c}
 echo '{"name": "A", "version": "14.0.1.0.0", "depends": ["b", "c"], "license": "GPL-3"}' > /tmp/myaddons/a/__manifest__.py
 echo '{"name": "B", "version": "14.0.1.0.0", "depends": ["crm"], "license": "Other Proprietary"}' > /tmp/myaddons/b/__manifest__.py
 echo '{"name": "C", "version": "14.0.1.0.0", "depends": ["mail"], "license": "LGPL-3"}' > /tmp/myaddons/c/__manifest__.py
+```
+
+It is possible to select modified addons compared to a target branch `target`.
+
+```console
+$ manifestoo --addons-path /tmp/myaddons --select-git-modified target list
+a
+b
+c
 ```
 
 The manifestoo `list` command is useful to list all installable addons in a

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,11 +17,13 @@ $ manifestoo [OPTIONS] COMMAND [ARGS]...
 **Options**:
 
 * `-d, --select-addons-dir DIRECTORY`: Select all installable addons found in this directory. This option may be repeated. The directories selected with this options are automatically added to the addons search path.
+* `-g, --select-git-modified TEXT`: Select all addons modified on current branch, relative to the given branch.
+* `-n, --select-git-new TEXT`: Select all new addons modified on current branch, relative to the given branch.
 * `--select-include, --select addon1,addon2,...`: Comma separated list of addons to select. These addons will be searched in the addons path.
 * `--select-exclude addon1,addon2,...`: Comma separated list of addons to exclude from selection. This option is useful in combination with `--select-addons-dir`.
 * `--select-core-addons`: Select the Odoo core addons (CE and EE) for the given series.
 * `--addons-path TEXT`: Expand addons path with this comma separated list of directories.
-* `--addons-path-from-import-odoo / --no-addons-path-from-import-odoo`: Expand addons path by trying to `import odoo` and looking at `odoo.addons.__path__`. This option is useful when addons have been installed with pip.  [default: True]
+* `--addons-path-from-import-odoo / --no-addons-path-from-import-odoo`: Expand addons path by trying to `import odoo` and looking at `odoo.addons.__path__`. This option is useful when addons have been installed with pip.  [default: addons-path-from-import-odoo]
 * `--addons-path-python PYTHON`: The python executable to use when importing `odoo.addons.__path__`. Defaults to the `python` executable found in PATH.
 * `--addons-path-from-odoo-cfg FILE`: Expand addons path by looking into the provided Odoo configuration file.   [env var: ODOO_RC]
 * `--odoo-series [8.0|9.0|10.0|11.0|12.0|13.0|14.0|15.0|16.0]`: Odoo series to use, in case it is not autodetected from addons version.  [env var: ODOO_VERSION, ODOO_SERIES]
@@ -39,7 +41,7 @@ $ manifestoo [OPTIONS] COMMAND [ARGS]...
 * `list`: Print the selected addons.
 * `list-codepends`: Print the co-dependencies of selected addons.
 * `list-depends`: Print the dependencies of selected addons.
-* `list-external-dependencies`: Print the external dependencies of selected...
+* `list-external-dependencies`: Print the external dependencies of...
 * `list-missing`: Print the missing dependencies of selected...
 * `tree`: Print the dependency tree of selected addons.
 
@@ -111,8 +113,8 @@ $ manifestoo list-codepends [OPTIONS]
 **Options**:
 
 * `--separator TEXT`: Separator character to use (by default, print one item per line).
-* `--transitive / --no-transitive`: Print all transitive co-dependencies.  [default: True]
-* `--include-selected / --no-include-selected`: Print the selected addons along with their co-dependencies.  [default: True]
+* `--transitive / --no-transitive`: Print all transitive co-dependencies.  [default: transitive]
+* `--include-selected / --no-include-selected`: Print the selected addons along with their co-dependencies.  [default: include-selected]
 * `--help`: Show this message and exit.
 
 ## `manifestoo list-depends`

--- a/src/manifestoo/git.py
+++ b/src/manifestoo/git.py
@@ -21,17 +21,46 @@ def check_branch_exists(branch: str) -> None:
         raise BranchNotFound(f"Cannot find branch {branch}. Aborting.")
 
 
+def _get_new_manifest_files(branch: str, current_branch: str) -> List[str]:
+    command_new = [
+        "git",
+        "diff",
+        "--name-only",
+        "--diff-filter",
+        "A",
+        branch,
+        current_branch,
+    ]
+    new_files = subprocess.check_output(command_new).decode().split()
+    return [f for f in new_files if f.endswith("/__manifest__.py")]
+
+
+def get_branch_new_addons(branch: str, addons_dirs: List[Path]) -> List[str]:
+    return _get_branch_addons_by(_get_new_manifest_files, branch, addons_dirs)
+
+
+def _get_modified_files(branch: str, current_branch: str) -> List[str]:
+    command_modified = ["git", "diff", "--name-only", branch, current_branch]
+    return subprocess.check_output(command_modified).decode().split()
+
+
 def get_branch_modified_addons(branch: str, addons_dirs: List[Path]) -> List[str]:
+    return _get_branch_addons_by(_get_modified_files, branch, addons_dirs)
+
+
+def _get_branch_addons_by(  # method: Callable[[str, str], list[str]]
+    method: Any, branch: str, addons_dirs: List[Path]
+) -> List[str]:
     check_branch_exists(branch)
     current_branch = get_current_branch()
-    command_modified = ["git", "diff", "--name-only", branch, current_branch]
-    modified_files = subprocess.check_output(command_modified).decode().split()
-    modified_addons = set()
-    for file_name in modified_files:
-        path = Path(file_name)
-        prefix = next((p for p in addons_dirs if p < path), None)
+    modified = method(branch, current_branch)
+    addons = set()
+    prefixes = [p.resolve() for p in addons_dirs]
+    for file_name in modified:
+        file_path = Path(file_name).parent.resolve()
+        prefix = next((p for p in prefixes if p in file_path.parents), None)
         if prefix:
             addon_file = re.sub(str(prefix), "", str(file_path))
             folder = re.sub("/.*", "", re.sub("^/", "", addon_file))
-            modified_addons.add(folder)
-    return list(modified_addons)
+            addons.add(folder)
+    return list(addons)

--- a/src/manifestoo/git.py
+++ b/src/manifestoo/git.py
@@ -1,0 +1,37 @@
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, List
+
+
+class BranchNotFound(Exception):
+    pass
+
+
+def get_current_branch() -> str:
+    command_current = ["git", "rev-parse", "--abbrev-ref", "HEAD"]
+    return subprocess.check_output(command_current).strip().decode()
+
+
+def check_branch_exists(branch: str) -> None:
+    try:
+        command_check = ["git", "rev-parse", "--verify", branch]
+        subprocess.check_output(command_check)
+    except subprocess.CalledProcessError:
+        raise BranchNotFound(f"Cannot find branch {branch}. Aborting.")
+
+
+def get_branch_modified_addons(branch: str, addons_dirs: List[Path]) -> List[str]:
+    check_branch_exists(branch)
+    current_branch = get_current_branch()
+    command_modified = ["git", "diff", "--name-only", branch, current_branch]
+    modified_files = subprocess.check_output(command_modified).decode().split()
+    modified_addons = set()
+    for file_name in modified_files:
+        path = Path(file_name)
+        prefix = next((p for p in addons_dirs if p < path), None)
+        if prefix:
+            addon_file = re.sub(str(prefix), "", str(file_path))
+            folder = re.sub("/.*", "", re.sub("^/", "", addon_file))
+            modified_addons.add(folder)
+    return list(modified_addons)

--- a/src/manifestoo/main.py
+++ b/src/manifestoo/main.py
@@ -14,7 +14,7 @@ from .commands.list_codepends import list_codepends_command
 from .commands.list_depends import list_depends_command
 from .commands.list_external_dependencies import list_external_dependencies_command
 from .commands.tree import tree_command
-from .git import get_branch_modified_addons
+from .git import get_branch_modified_addons, get_branch_new_addons
 from .options import MainOptions
 from .utils import ensure_odoo_series, not_implemented, print_list
 from .version import core_version, version
@@ -56,6 +56,16 @@ def callback(
             "Select all addons modified on current branch,"
             " relative to the given branch."
         ),
+    ),
+    select_git_new: str = typer.Option(
+        None,
+        "--select-git-new",
+        "-n",
+        help=(
+            "Select all new addons modified on current branch,"
+            " relative to the given branch."
+        ),
+        show_default=False,
     ),
     select_include: Optional[str] = typer.Option(
         None,
@@ -198,6 +208,9 @@ def callback(
             select_git_modified, main_options.addons_path
         )
         main_options.addons_selection.add_addon_names(",".join(modified_addons))
+    if select_git_new:
+        new_addons = get_branch_new_addons(select_git_new, main_options.addons_path)
+        main_options.addons_selection.add_addon_names(",".join(new_addons))
     if select_include:
         main_options.addons_selection.add_addon_names(select_include)
     if select_exclude:

--- a/src/manifestoo/main.py
+++ b/src/manifestoo/main.py
@@ -14,6 +14,7 @@ from .commands.list_codepends import list_codepends_command
 from .commands.list_depends import list_depends_command
 from .commands.list_external_dependencies import list_external_dependencies_command
 from .commands.tree import tree_command
+from .git import get_branch_modified_addons
 from .options import MainOptions
 from .utils import ensure_odoo_series, not_implemented, print_list
 from .version import core_version, version
@@ -46,6 +47,15 @@ def callback(
             "automatically added to the addons search path."
         ),
         show_default=False,
+    ),
+    select_git_modified: str = typer.Option(
+        None,
+        "--select-git-modified",
+        "-g",
+        help=(
+            "Select all addons modified on current branch,"
+            " relative to the given branch."
+        ),
     ),
     select_include: Optional[str] = typer.Option(
         None,
@@ -183,6 +193,11 @@ def callback(
     # addons selection
     if select_addons_dirs:
         main_options.addons_selection.add_addons_dirs(select_addons_dirs)
+    if select_git_modified:
+        modified_addons = get_branch_modified_addons(
+            select_git_modified, main_options.addons_path
+        )
+        main_options.addons_selection.add_addon_names(",".join(modified_addons))
     if select_include:
         main_options.addons_selection.add_addon_names(select_include)
     if select_exclude:

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,5 +1,8 @@
+import functools
+import os
+import subprocess
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from manifestoo.addons_selection import AddonsSelection
 from manifestoo_core.addon import Addon
@@ -31,3 +34,54 @@ def mock_addons_selection(addon_names: str) -> AddonsSelection:
     addons_selection = AddonsSelection()
     addons_selection.add_addon_names(addon_names)
     return addons_selection
+
+
+def restore_cwd(function):
+    @functools.wraps(function)
+    def decorator(*args, **kwargs):
+        cwd = os.getcwd()
+        try:
+            return function(*args, **kwargs)
+        finally:
+            os.chdir(cwd)
+
+    return decorator
+
+
+@restore_cwd
+def run_in_path(path: Path, function, *args, **kwargs):
+    cd_git_root(path)
+    return function(*args, **kwargs)
+
+
+def cd_git_root(git_root: Path):
+    os.chdir(git_root)
+
+
+@restore_cwd
+def git_init(git_root: Path):
+    cd_git_root(git_root)
+    subprocess.check_output(["git", "init"])
+    subprocess.check_output(["git", "config", "user.email", "you@example.com"])
+    subprocess.check_output(["git", "config", "user.name", "Your Name"])
+
+
+@restore_cwd
+def git_commit(git_root: Path, paths: Optional[Path] = None):
+    cd_git_root(git_root)
+    paths = paths or ["."]
+    subprocess.check_output(["git", "add"] + paths)
+    subprocess.check_output(["git", "commit", "-m", "*"])
+
+
+@restore_cwd
+def git_checkout(git_root: Path, branch: str, new: bool = False):
+    cd_git_root(git_root)
+    command = ["git", "checkout", "-b"] if new else ["git", "checkout"]
+    subprocess.check_output(command + [branch])
+
+
+def modify_addon_file(addon_dir: Path, file_path: Optional[str] = None):
+    file_path = file_path or "__manifest__.py"
+    with open(addon_dir / file_path, "a") as file_object:
+        file_object.write("\n# useless change\n")

--- a/tests/test_cmd_list_git.py
+++ b/tests/test_cmd_list_git.py
@@ -1,0 +1,63 @@
+import pytest
+from typer.testing import CliRunner
+
+from manifestoo.git import BranchNotFound, get_branch_modified_addons
+from manifestoo.main import app
+
+from .common import (
+    git_checkout,
+    git_commit,
+    git_init,
+    modify_addon_file,
+    populate_addons_dir,
+    run_in_path,
+)
+
+
+def test_git_selection(tmp_path):
+    addons_path = tmp_path / "addons"  # this way we can check project files in
+    addons = {"a": {"depends": ["b"]}, "b": {}}
+    new_addons = {"c": {}}
+    git_init(tmp_path)
+    populate_addons_dir(addons_path, addons)
+    git_commit(tmp_path)
+    git_checkout(tmp_path, "develop", new=True)
+    populate_addons_dir(addons_path, new_addons)
+    git_commit(tmp_path)
+    modify_addon_file(addons_path / "b")
+    git_commit(tmp_path)
+
+    # now we put things that are NOT in addons to check it does not pollute output
+    (tmp_path / ".gitignore").touch()
+    git_commit(tmp_path)
+    # this one is a bit more tricky:
+    (addons_path / "README.md").touch()
+    git_commit(tmp_path)
+
+    with pytest.raises(BranchNotFound):  # check it fails on non-existent branch
+        run_in_path(tmp_path, get_branch_modified_addons, "main", [addons_path])
+
+    # check get all addons modified on develop branch
+    runner = CliRunner(mix_stderr=False)
+    result = run_in_path(
+        tmp_path,
+        runner.invoke,
+        app,
+        [f"--addons-path={addons_path}", "-g", "master", "list"],
+        catch_exceptions=False,
+    )
+    assert not result.exception
+    assert result.exit_code == 0
+    assert result.stdout == "b\nc\n"
+
+    # now check we only get new addons
+    result = run_in_path(
+        tmp_path,
+        runner.invoke,
+        app,
+        [f"--addons-path={addons_path}", "-n", "master", "list"],
+        catch_exceptions=False,
+    )
+    assert not result.exception
+    assert result.exit_code == 0
+    assert result.stdout == "c\n"


### PR DESCRIPTION
This PR adds :
- automatically selects modified addons on the current branch compared to a target branch
- automatically selects newly added addons on the current branch compared to a target branch

Note that it uses popen instead of the git addon not to introduce any new dependency.