### PR TITLE
add a few valid dependency cases

### DIFF
--- a/src/manifestoo/license.py
+++ b/src/manifestoo/license.py
@@ -4,25 +4,22 @@ from typing import Dict, Optional
 
 class LicenseType(Enum):
     PROPRIETARY = 1
-    PERMISSIVE = 2  # MIT, Apache
+    PERMISSIVE = 2  # MIT
     WEAKLY_PROTECTIVE = 3  # LGPL
     STRONGLY_PROTECTIVE = 4  # GPL
     NETWORK_PROTECTIVE = 5  # AGPL
 
 
 def can_depend_on(work_license: LicenseType, dependency_license: LicenseType) -> bool:
-    if work_license == LicenseType.PROPRIETARY:
+    if work_license in (
+        LicenseType.PROPRIETARY,
+        LicenseType.PERMISSIVE,
+        LicenseType.WEAKLY_PROTECTIVE,
+    ):
         return dependency_license in (
             LicenseType.PROPRIETARY,
             LicenseType.PERMISSIVE,
             LicenseType.WEAKLY_PROTECTIVE,
-        )
-    elif work_license == LicenseType.PERMISSIVE:
-        return dependency_license in (LicenseType.PERMISSIVE,)
-    elif work_license == LicenseType.WEAKLY_PROTECTIVE:
-        return dependency_license in (
-            LicenseType.WEAKLY_PROTECTIVE,
-            LicenseType.PERMISSIVE,
         )
     elif work_license == LicenseType.STRONGLY_PROTECTIVE:
         return dependency_license in (


### PR DESCRIPTION
disclaimer: I'm not a lawyer :)

based on [Odoo's licenses](https://www.odoo.com/documentation/16.0/legal/licenses.html):
- LGPL-3/MIT module can depend on OEEL-1/OPL-1 module

also MIT module can depend on LGPL-3 module (but not on Apache module; removed Apache from the comment to avoid ambiguity; wasn't taken into account anyway)