### PR TITLE
Add topological sort option to list* commands

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,7 +26,7 @@ $ manifestoo [OPTIONS] COMMAND [ARGS]...
 * `--addons-path-from-import-odoo / --no-addons-path-from-import-odoo`: Expand addons path by trying to `import odoo` and looking at `odoo.addons.__path__`. This option is useful when addons have been installed with pip.  [default: addons-path-from-import-odoo]
 * `--addons-path-python PYTHON`: The python executable to use when importing `odoo.addons.__path__`. Defaults to the `python` executable found in PATH.
 * `--addons-path-from-odoo-cfg FILE`: Expand addons path by looking into the provided Odoo configuration file.   [env var: ODOO_RC]
-* `--odoo-series [8.0|9.0|10.0|11.0|12.0|13.0|14.0|15.0|16.0]`: Odoo series to use, in case it is not autodetected from addons version.  [env var: ODOO_VERSION, ODOO_SERIES]
+* `--odoo-series [8.0|9.0|10.0|11.0|12.0|13.0|14.0|15.0|16.0|17.0]`: Odoo series to use, in case it is not autodetected from addons version.  [env var: ODOO_VERSION, ODOO_SERIES]
 * `-v, --verbose`
 * `-q, --quiet`
 * `--version`
@@ -95,6 +95,7 @@ $ manifestoo list [OPTIONS]
 **Options**:
 
 * `--separator TEXT`: Separator character to use (by default, print one item per line).
+* `--sort TEXT`: Choice between 'alphabetical' and 'topological'. Topological sorting is useful when seeking a migration order.  [default: alphabetical]
 * `--help`: Show this message and exit.
 
 ## `manifestoo list-codepends`
@@ -115,6 +116,7 @@ $ manifestoo list-codepends [OPTIONS]
 * `--separator TEXT`: Separator character to use (by default, print one item per line).
 * `--transitive / --no-transitive`: Print all transitive co-dependencies.  [default: transitive]
 * `--include-selected / --no-include-selected`: Print the selected addons along with their co-dependencies.  [default: include-selected]
+* `--sort TEXT`: Choice between 'alphabetical' and 'topological'. Topological sorting is useful when seeking a migration order.  [default: alphabetical]
 * `--help`: Show this message and exit.
 
 ## `manifestoo list-depends`
@@ -134,6 +136,7 @@ $ manifestoo list-depends [OPTIONS]
 * `--include-selected`: Print the selected addons along with their dependencies.
 * `--ignore-missing`: Do not fail if dependencies are not found in addons path. This only applies to top level (selected) addons and transitive dependencies.
 * `--as-pip-requirements`
+* `--sort TEXT`: Choice between 'alphabetical' and 'topological'. Topological sorting is useful when seeking a migration order.  [default: alphabetical]
 * `--help`: Show this message and exit.
 
 ## `manifestoo list-external-dependencies`

--- a/news/62.feature
+++ b/news/62.feature
@@ -1,0 +1,1 @@
+Add ``--sort`` option on list, list-depends and list-codepends.

--- a/src/manifestoo/addon_sorter.py
+++ b/src/manifestoo/addon_sorter.py
@@ -1,0 +1,65 @@
+import sys
+from typing import Dict, Iterable, Set
+
+import typer
+
+from manifestoo_core.addons_set import AddonsSet
+
+from . import echo
+from .exceptions import CycleErrorExit
+
+
+class AddonSorter:
+    @staticmethod
+    def from_name(name: str) -> "AddonSorter":
+        if name == "alphabetical":
+            return AddonSorterAlphabetical()
+        elif name == "topological":
+            if sys.version_info < (3, 9):
+                echo.error(
+                    "The 'topological' sorter requires Python 3.9 or later",
+                    err=False,
+                )
+                raise typer.Exit(1)
+            return AddonSorterTopological()
+        else:
+            echo.error(f"Unknown sorter {name}", err=False)
+            raise typer.Exit(1)
+
+    def sort(
+        self, addons_selection: Iterable[str], addon_set: AddonsSet
+    ) -> Iterable[str]:
+        raise NotImplementedError()
+
+
+class AddonSorterAlphabetical(AddonSorter):
+    def sort(
+        self, addons_selection: Iterable[str], addon_set: AddonsSet
+    ) -> Iterable[str]:
+        return sorted(addons_selection)
+
+
+class AddonSorterTopological(AddonSorter):
+    def sort(
+        self, addons_selection: Iterable[str], addon_set: AddonsSet
+    ) -> Iterable[str]:
+        result_dict: Dict[str, Set[str]] = {}
+        for addon_name in addons_selection:
+            try:
+                addon = addon_set[addon_name]
+                result_dict[addon_name] = set(
+                    depend
+                    for depend in addon.manifest.depends
+                    if depend in addons_selection
+                )
+            except KeyError:
+                echo.debug(f"Addon {addon_name} not found in addon set")
+        from graphlib import CycleError, TopologicalSorter
+
+        topological_sorted_res = TopologicalSorter(result_dict)
+        try:
+            res = list(topological_sorted_res.static_order())
+        except CycleError as e:
+            echo.error("Cycle detected in dependencies", err=False)
+            raise CycleErrorExit(1) from e
+        return res

--- a/src/manifestoo/commands/list.py
+++ b/src/manifestoo/commands/list.py
@@ -1,7 +1,16 @@
-from typing import Iterable
+from typing import Iterable, Optional
 
+from manifestoo_core.addons_set import AddonsSet
+
+from ..addon_sorter import AddonSorter, AddonSorterAlphabetical
 from ..addons_selection import AddonsSelection
 
 
-def list_command(addons_selection: AddonsSelection) -> Iterable[str]:
-    return sorted(addons_selection)
+def list_command(
+    addons_selection: AddonsSelection,
+    addons_set: AddonsSet,
+    addon_sorter: Optional[AddonSorter] = None,
+) -> Iterable[str]:
+    if not addon_sorter:
+        addon_sorter = AddonSorterAlphabetical()
+    return addon_sorter.sort(addons_selection, addons_set)

--- a/src/manifestoo/commands/list_codepends.py
+++ b/src/manifestoo/commands/list_codepends.py
@@ -1,7 +1,8 @@
-from typing import Iterable, Set
+from typing import Iterable, Optional, Set
 
 from manifestoo_core.addons_set import AddonsSet
 
+from ..addon_sorter import AddonSorter, AddonSorterAlphabetical
 from ..addons_selection import AddonsSelection
 
 
@@ -10,14 +11,18 @@ def list_codepends_command(
     addons_set: AddonsSet,
     transitive: bool = True,
     include_selected: bool = True,
+    addon_sorter: Optional[AddonSorter] = None,
 ) -> Iterable[str]:
+    if not addon_sorter:
+        addon_sorter = AddonSorterAlphabetical()
     result: Set[str] = set(addons_selection) if include_selected else set()
     codeps = direct_codependencies(addons_selection, addons_set, result)
     result |= codeps
     while transitive and codeps:
         codeps = direct_codependencies(codeps, addons_set, result)
         result |= codeps
-    return result if include_selected else result - addons_selection
+    res = result if include_selected else result - addons_selection
+    return addon_sorter.sort(res, addons_set)
 
 
 def direct_codependencies(

--- a/src/manifestoo/commands/list_depends.py
+++ b/src/manifestoo/commands/list_depends.py
@@ -1,7 +1,8 @@
-from typing import Iterable, Set, Tuple
+from typing import Iterable, Optional, Set, Tuple
 
 from manifestoo_core.addons_set import AddonsSet
 
+from ..addon_sorter import AddonSorter, AddonSorterAlphabetical
 from ..addons_selection import AddonsSelection
 from ..dependency_iterator import dependency_iterator
 
@@ -11,7 +12,10 @@ def list_depends_command(
     addons_set: AddonsSet,
     transitive: bool = False,
     include_selected: bool = False,
+    addon_sorter: Optional[AddonSorter] = None,
 ) -> Tuple[Iterable[str], Iterable[str]]:
+    if not addon_sorter:
+        addon_sorter = AddonSorterAlphabetical()
     result: Set[str] = set()
     missing: Set[str] = set()
     for addon_name, addon in dependency_iterator(
@@ -23,4 +27,4 @@ def list_depends_command(
             missing.add(addon_name)
         else:
             result.update(set(addon.manifest.depends) - set(addons_selection))
-    return sorted(result), missing
+    return addon_sorter.sort(result, addons_set), missing

--- a/src/manifestoo/exceptions.py
+++ b/src/manifestoo/exceptions.py
@@ -1,0 +1,5 @@
+from typer import Exit
+
+
+class CycleErrorExit(Exit):
+    pass

--- a/tests/test_cmd_list.py
+++ b/tests/test_cmd_list.py
@@ -5,12 +5,18 @@ from typer.testing import CliRunner
 from manifestoo.commands.list import list_command
 from manifestoo.main import app
 
-from .common import mock_addons_selection, populate_addons_dir
+from .common import mock_addons_selection, mock_addons_set, populate_addons_dir
 
 
 def test_basic():
     addons_selection = mock_addons_selection("b,a")
-    assert list_command(addons_selection) == ["a", "b"]
+    addons_set = mock_addons_set(
+        {
+            "a": {},
+            "b": {},
+        }
+    )
+    assert list_command(addons_selection, addons_set) == ["a", "b"]
 
 
 def test_integration(tmp_path):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [gh-actions]
 python =
     3.7: py37
-    3.8: py38, typing
+    3.8: py38
     3.9: py39, typing
     3.10: py310, typing
     3.11: py311, typing, pypi-description


### PR DESCRIPTION
Add a new --sort option on the list-depend command allowing to apply a topological sorting to the result.
https://docs.python.org/3/library/graphlib.html