### PR TITLE
fix link in api docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3,5 +3,6 @@
 This project does not expose a programmatic API. Only the command line interface is
 stable and documented.
 
-A public programmatic API is being developped in `manifestoo_core
-<https://pypi.org/project/manifestsoo-core>` on which this project relies.
+A public programmatic API is being developed in
+[manifestoo_core](https://pypi.org/project/manifestoo-core/)
+on which this project relies.


### PR DESCRIPTION
Use markdown syntax, fix link and fix typo.