### PR TITLE
Don't assume odoo.addons.__path__ is a list

### DIFF
--- a/news/68.bugfix
+++ b/news/68.bugfix
@@ -1,0 +1,1 @@
+Don't crash if ``odoo.addons.__path__`` is a `_NamespacePath`.

--- a/src/manifestoo/addons_path.py
+++ b/src/manifestoo/addons_path.py
@@ -24,7 +24,7 @@ else:
     path = odoo.modules.module.ad_paths
 
 with open(sys.argv[1], "wb") as f:
-    f.write(repr(path).encode("utf-8"))
+    f.write(repr(list(path)).encode("utf-8"))
 """
 
 


### PR DESCRIPTION
Wen the usual pkgutil.extend_path idiom is used, this is not the case.