### PR TITLE
[IMP] Added the ability to unfold already present dependencies in tree

### DIFF
--- a/news/75.feature
+++ b/news/75.feature
@@ -1,0 +1,1 @@
+Added the ability to print the inverted dependency tree using the `--inverse` command line option.

--- a/src/manifestoo/commands/tree.py
+++ b/src/manifestoo/commands/tree.py
@@ -31,7 +31,11 @@ class Node:
         return addon_name
 
     def print(
-        self, odoo_series: OdooSeries, fold_core_addons: bool, inverse: bool
+        self,
+        odoo_series: OdooSeries,
+        fold_core_addons: bool,
+        inverse: bool,
+        unfold_seen_addons: bool,
     ) -> None:
         seen: Set[Node] = set()
 
@@ -42,7 +46,9 @@ class Node:
             TEE = "├── "
             LAST = "└── "
             typer.echo(f"{''.join(indent)}{node.addon_name}", nl=False)
-            if node in seen:
+            # When unfold_seen_addons is True, there will be an infinite recursion
+            # in the presence of a cyclic dependency
+            if not unfold_seen_addons and node in seen:
                 typer.secho(" ⬆", dim=True)
                 return
             typer.secho(f" ({node.sversion(odoo_series)})", dim=True)
@@ -86,6 +92,7 @@ def tree_command(
     odoo_series: OdooSeries,
     fold_core_addons: bool,
     inverse: bool,
+    unfold_seen_addons: bool,
 ) -> None:
     nodes: Dict[NodeKey, Node] = {}
 
@@ -117,4 +124,4 @@ def tree_command(
         root_nodes = [node for node in nodes.values() if not node.children]
     root_nodes = sorted(root_nodes, key=lambda n: n.addon_name)
     for root_node in root_nodes:
-        root_node.print(odoo_series, fold_core_addons, inverse)
+        root_node.print(odoo_series, fold_core_addons, inverse, unfold_seen_addons)

--- a/src/manifestoo/main.py
+++ b/src/manifestoo/main.py
@@ -501,6 +501,12 @@ def tree(
         help="Display the tree in inverse mode. Not available in interactive mode.",
         show_default=False,
     ),
+    unfold_seen_addons: bool = typer.Option(
+        False,
+        "--unfold-seen-addons",
+        help="Expand dependencies that are already present in the tree.",
+        show_default=False,
+    ),
 ) -> None:
     """Print the dependency tree of selected addons."""
     main_options: MainOptions = ctx.obj
@@ -524,4 +530,5 @@ def tree(
             main_options.odoo_series,
             fold_core_addons,
             inverse,
+            unfold_seen_addons,
         )

--- a/src/manifestoo/main.py
+++ b/src/manifestoo/main.py
@@ -495,12 +495,22 @@ def tree(
         help="Display an interactive tree.",
         show_default=False,
     ),
+    inverse: bool = typer.Option(
+        False,
+        "--inverse",
+        help="Display the tree in inverse mode. Not available in interactive mode.",
+        show_default=False,
+    ),
 ) -> None:
     """Print the dependency tree of selected addons."""
     main_options: MainOptions = ctx.obj
     ensure_odoo_series(main_options.odoo_series)
     assert main_options.odoo_series
     if interactive:
+        if inverse:
+            raise typer.BadParameter(
+                "The --inverse option is not available in interactive mode."
+            )
         interactive_tree_command(
             main_options.addons_selection,
             main_options.addons_set,
@@ -513,4 +523,5 @@ def tree(
             main_options.addons_set,
             main_options.odoo_series,
             fold_core_addons,
+            inverse,
         )

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,11 +1,12 @@
 import textwrap
+from pathlib import Path
 
 from manifestoo.main import app
 
 from .common import CliRunner, populate_addons_dir
 
 
-def test_integration(tmp_path):
+def _init_test_addons(tmp_path: Path):
     addons = {
         "a": {"version": "13.0.1.0.0", "depends": ["b", "c"]},
         "b": {"depends": ["base", "mail"]},
@@ -14,6 +15,10 @@ def test_integration(tmp_path):
         "base": {},
     }
     populate_addons_dir(tmp_path, addons)
+
+
+def test_integration(tmp_path: Path):
+    _init_test_addons(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
         app,
@@ -30,5 +35,29 @@ def test_integration(tmp_path):
             └── c (no version)
                 ├── account (13.0+c)
                 └── b ⬆
+        """
+    )
+
+
+def test_integration_inverse(tmp_path: Path):
+    _init_test_addons(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["--select=a", f"--addons-path={tmp_path}", "tree", "--inverse"],
+        catch_exceptions=False,
+    )
+    assert not result.exception
+    assert result.exit_code == 0, result.stderr
+    assert result.stdout == textwrap.dedent(
+        """\
+            account (13.0+c)
+            └── c (no version)
+                └── a (13.0.1.0.0)
+            mail (✘ not installed)
+            └── b (no version)
+                ├── a (13.0.1.0.0)
+                └── c (no version)
+                    └── a ⬆
         """
     )

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -61,3 +61,26 @@ def test_integration_inverse(tmp_path: Path):
                     └── a ⬆
         """
     )
+
+
+def test_integration_unfold_seen_addons(tmp_path: Path):
+    _init_test_addons(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["--select=a", f"--addons-path={tmp_path}", "tree", "--unfold-seen-addons"],
+        catch_exceptions=False,
+    )
+    assert not result.exception
+    assert result.exit_code == 0, result.stderr
+    assert result.stdout == textwrap.dedent(
+        """\
+            a (13.0.1.0.0)
+            ├── b (no version)
+            │   └── mail (✘ not installed)
+            └── c (no version)
+                ├── account (13.0+c)
+                └── b (no version)
+                    └── mail (✘ not installed)
+        """
+    )


### PR DESCRIPTION
Added the `--unfold-seen-addons` options, which changes:
```
            a (13.0.1.0.0)
            ├── b (no version)
            │   └── mail (✘ not installed)
            └── c (no version)
                ├── account (13.0+c)
                └── b ⬆
```

To:
```
            a (13.0.1.0.0)
            ├── b (no version)
            │   └── mail (✘ not installed)
            └── c (no version)
                ├── account (13.0+c)
                └── b (no version)
                    └── mail (✘ not installed)
```

⚠️  There is a risk of infinite recursion in case of a cyclic dependency, let's discuss whether this case should be handled ⚠️ 
