### PR TITLE
check-licenses: Allow dependency on proprietary for LGPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ a (14.0.1.0.0)
 To check that licenses are compatibles, use the `check-licenses` command:
 
 ```console
-$ moo -d /tmp/myaddons check-licenses
+$ manifestoo -d /tmp/myaddons check-licenses --transitive
 a (GPL-3) depends on b (Other Proprietary)
 ```
 

--- a/src/manifestoo/license.py
+++ b/src/manifestoo/license.py
@@ -21,6 +21,7 @@ def can_depend_on(work_license: LicenseType, dependency_license: LicenseType) ->
         return dependency_license in (LicenseType.PERMISSIVE,)
     elif work_license == LicenseType.WEAKLY_PROTECTIVE:
         return dependency_license in (
+            LicenseType.PROPRIETARY,
             LicenseType.WEAKLY_PROTECTIVE,
             LicenseType.PERMISSIVE,
         )

--- a/tests/test_cmd_check_licenses.py
+++ b/tests/test_cmd_check_licenses.py
@@ -111,6 +111,41 @@ def test_v12_ce_lgpl():
     assert errors == []
 
 
+def test_v16_ee_lgpl():
+    addons_set = mock_addons_set(
+        {
+            "a": {"depends": ["timer"], "license": "LGPL-3"},
+            "timer": {},
+        }
+    )
+    addons_selection = mock_addons_selection("a")
+    errors = check_licenses_command(
+        addons_selection,
+        addons_set,
+        transitive=False,
+        odoo_series=OdooSeries.v16_0,
+    )
+    assert errors == []
+
+
+def test_v16_agpl_ee_transitive():
+    addons_set = mock_addons_set(
+        {
+            "a": {"depends": ["b"], "license": "AGPL-3"},
+            "b": {"depends": ["timer"], "license": "LGPL-3"},
+            "timer": {},
+        }
+    )
+    addons_selection = mock_addons_selection("a")
+    errors = check_licenses_command(
+        addons_selection,
+        addons_set,
+        transitive=True,
+        odoo_series=OdooSeries.v16_0,
+    )
+    assert errors == ["a (AGPL-3) depends on timer (OEEL-1)"]
+
+
 def test_v12_ee_proprietary():
     addons_set = mock_addons_set(
         {


### PR DESCRIPTION
LGPL is a license that is meant to be used with proprietary code.

Update documentation to indicate to use the transitive flag.

Add test case for now allowed dependency and another for an issue with transitive dependency.

This is similar to #74 but only changing the lgpl/proprietary dependency.
The transitive dependency can already be checked in the current version, I’ve just updated the main README to indicate to use it.